### PR TITLE
Migrate to use v0.14 API

### DIFF
--- a/fluent-plugin-azureeventhubs.gemspec
+++ b/fluent-plugin-azureeventhubs.gemspec
@@ -19,4 +19,5 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_dependency "fluentd", [">= 0.14.15", "< 2"]
 end

--- a/lib/fluent/plugin/out_azureeventhubs_buffered.rb
+++ b/lib/fluent/plugin/out_azureeventhubs_buffered.rb
@@ -42,6 +42,10 @@ module Fluent::Plugin
       [tag, time, record].to_msgpack
     end
 
+    def formatted_to_msgpack_binary?
+      true
+    end
+
     def write(chunk)
       chunk.msgpack_each { |tag, time, record|
         p record.to_s

--- a/lib/fluent/plugin/out_azureeventhubs_buffered.rb
+++ b/lib/fluent/plugin/out_azureeventhubs_buffered.rb
@@ -35,6 +35,7 @@ module Fluent::Plugin
         require_relative 'azureeventhubs/http'
         @sender = AzureEventHubsHttpSender.new(@connection_string, @hub_name, @expiry_interval,@proxy_addr,@proxy_port,@open_timeout,@read_timeout)
       end
+      raise Fluent::ConfigError, "'tag' in chunk_keys is required." if not @chunk_key_tag
     end
 
     def format(tag, time, record)

--- a/lib/fluent/plugin/out_azureeventhubs_buffered.rb
+++ b/lib/fluent/plugin/out_azureeventhubs_buffered.rb
@@ -1,7 +1,11 @@
-#module Fluent
+module Fluent::Plugin
 
-  class AzureEventHubsOutputBuffered < Fluent::BufferedOutput
+  class AzureEventHubsOutputBuffered < Output
     Fluent::Plugin.register_output('azureeventhubs_buffered', self)
+
+    helpers :compat_parameters
+
+    DEFAULT_BUFFER_TYPE = "memory"
 
     config_param :connection_string, :string
     config_param :hub_name, :string
@@ -9,14 +13,20 @@
     config_param :include_time, :bool, :default => false
     config_param :tag_time_name, :string, :default => 'time'
     config_param :expiry_interval, :integer, :default => 3600 # 60min
-    config_param :type, :string, :default => 'https' # https / amqps (Not Implemented) 
+    config_param :type, :string, :default => 'https' # https / amqps (Not Implemented)
     config_param :proxy_addr, :string, :default => ''
     config_param :proxy_port, :integer,:default => 3128
     config_param :open_timeout, :integer,:default => 60
     config_param :read_timeout, :integer,:default => 60
     config_param :message_properties, :hash, :default => nil
 
+    config_section :buffer do
+      config_set_default :@type, DEFAULT_BUFFER_TYPE
+      config_set_default :chunk_keys, ['tag']
+    end
+
     def configure(conf)
+      compat_parameters_convert(conf, :buffer)
       super
       case @type
       when 'amqps'
@@ -44,5 +54,4 @@
       }
     end
   end
-#end
-
+end

--- a/lib/fluent/plugin/out_azureeventhubs_buffered.rb
+++ b/lib/fluent/plugin/out_azureeventhubs_buffered.rb
@@ -3,7 +3,7 @@ module Fluent::Plugin
   class AzureEventHubsOutputBuffered < Output
     Fluent::Plugin.register_output('azureeventhubs_buffered', self)
 
-    helpers :compat_parameters
+    helpers :compat_parameters, :inject
 
     DEFAULT_BUFFER_TYPE = "memory"
 
@@ -26,7 +26,7 @@ module Fluent::Plugin
     end
 
     def configure(conf)
-      compat_parameters_convert(conf, :buffer)
+      compat_parameters_convert(conf, :buffer, :inject)
       super
       case @type
       when 'amqps'
@@ -38,6 +38,7 @@ module Fluent::Plugin
     end
 
     def format(tag, time, record)
+      record = inject_values_to_record(tag, time, record)
       [tag, time, record].to_msgpack
     end
 


### PR DESCRIPTION
Hi, I've tried to use v0.14 API in this plugin.
I've tested with the following config(without sensitive information):

```aconf
<source>
  @type forward
</source>
<match pattern>
  @type azureeventhubs_buffered

  connection_string "Endpoint=sb://<My Service EndPoint>.servicebus.windows.net/;SharedAccessKeyName=<My Key Name>;SharedAccessKey=<My Azure Account Key>"
  hub_name          <My Eventhub Name>
  include_tag       false
  include_time      false
  type              https
</match>
```

And please refer http://docs.fluentd.org/v0.14/articles/plugin-update-from-v12 before release new version.