### PR TITLE
Add support for proxy username and password

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ Or install it yourself as:
   expiry_interval   <Integer number> # Signature expiration time interval in seconds. [Optional: default => 3600 (60min)]
   proxy_addr       <Host or IP> # Address of the proxy [Optional]
   proxy_port	   <Integer>   # Proxy port. [Optional: default => 3128]
+  proxy_user       <Username>  # Proxy username
+  proxy_pass       <Password>  # Proxy password
   read_timeout     <Integer>   # HTTP Read timeout in seconds[Optional: default => 60]
   open_timeout     <Integer>   # HTTP Open timeout in seconds[Optional: default => 60]
   message_properties <Json Object> # A json object of key/value pairs to add Properties to the events being sent to EventHubs [Optional: default => nil]

--- a/lib/fluent/plugin/azureeventhubs/http.rb
+++ b/lib/fluent/plugin/azureeventhubs/http.rb
@@ -1,6 +1,6 @@
 
 class AzureEventHubsHttpSender
-  def initialize(connection_string, hub_name, expiry=3600,proxy_addr='',proxy_port=3128,open_timeout=60,read_timeout=60)
+  def initialize(connection_string, hub_name, expiry=3600,proxy_addr='',proxy_port=3128,proxy_user='',proxy_pass='',open_timeout=60,read_timeout=60)
     require 'openssl'
     require 'base64'
     require 'net/http'
@@ -12,6 +12,8 @@ class AzureEventHubsHttpSender
     @expiry_interval = expiry
     @proxy_addr = proxy_addr
     @proxy_port = proxy_port
+    @proxy_user = proxy_user
+    @proxy_pass = proxy_pass
     @open_timeout = open_timeout
     @read_timeout = read_timeout
 
@@ -61,7 +63,7 @@ class AzureEventHubsHttpSender
         https.open_timeout = @open_timeout
         https.read_timeout = @read_timeout
     else
-    	https = Net::HTTP.new(@uri.host, @uri.port,@proxy_addr,@proxy_port)
+    	https = Net::HTTP.new(@uri.host, @uri.port,@proxy_addr,@proxy_port,@proxy_user,@proxy_pass)
         https.open_timeout = @open_timeout
         https.read_timeout = @read_timeout
     end

--- a/lib/fluent/plugin/out_azureeventhubs_buffered.rb
+++ b/lib/fluent/plugin/out_azureeventhubs_buffered.rb
@@ -16,6 +16,8 @@ module Fluent::Plugin
     config_param :type, :string, :default => 'https' # https / amqps (Not Implemented)
     config_param :proxy_addr, :string, :default => ''
     config_param :proxy_port, :integer,:default => 3128
+    config_param :proxy_user, :string, :default => ''
+    config_param :proxy_pass, :string, :default => ''
     config_param :open_timeout, :integer,:default => 60
     config_param :read_timeout, :integer,:default => 60
     config_param :message_properties, :hash, :default => nil
@@ -33,7 +35,7 @@ module Fluent::Plugin
         raise NotImplementedError
       else
         require_relative 'azureeventhubs/http'
-        @sender = AzureEventHubsHttpSender.new(@connection_string, @hub_name, @expiry_interval,@proxy_addr,@proxy_port,@open_timeout,@read_timeout)
+        @sender = AzureEventHubsHttpSender.new(@connection_string, @hub_name, @expiry_interval,@proxy_addr,@proxy_port,@proxy_user,@proxy_pass@open_timeout,@read_timeout)
       end
       raise Fluent::ConfigError, "'tag' in chunk_keys is required." if not @chunk_key_tag
     end


### PR DESCRIPTION
This plugin currently can't handle a proxy that is username/password protected. This PR aims to rectify this.