### PR TITLE
Creating a batching ability

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ Or install it yourself as:
   read_timeout     <Integer>   # HTTP Read timeout in seconds[Optional: default => 60]
   open_timeout     <Integer>   # HTTP Open timeout in seconds[Optional: default => 60]
   message_properties <Json Object> # A json object of key/value pairs to add Properties to the events being sent to EventHubs [Optional: default => nil]
+  batch             (true|false) # true: Send a collection of records to Event Hubs instead of one message per record. [Optional: default => false]
+  max_batch_size    <Integer> # The max number of records to send in a single message to Event Hubs. [Optional: default => 20]
+  print_records     (true|false) # true: Print each record as it is processed. [Optional: default => true]
 </match>
 ```
 

--- a/fluent-plugin-azureeventhubs.gemspec
+++ b/fluent-plugin-azureeventhubs.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "fluent-plugin-azureeventhubs"
-  spec.version       = "0.0.6"
+  spec.version       = "0.0.7"
   spec.authors       = ["Hidemasa Togashi", "Toddy Mladenov", "Justin Seely"]
   spec.email         = ["togachiro@gmail.com", "toddysm@gmail.com"]
   spec.summary       = "Fluentd output plugin for Azure Event Hubs"


### PR DESCRIPTION
It would be nice to be able to send a larger group of events to the Event Hub with one call.  This modification allows batching of sends, so that multiple events can be sent, reducing the amount of calls into Event Hubs.  Also making the printing of the objects optional.

By default, this will function just as it did before, but the extra batching can be turned on with a flag, and the printing can be turned off with another flag.